### PR TITLE
Remove float style

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -170,10 +170,6 @@ main h2 {
   position: relative;
 }
 
-main h2 + table {
-  float: left;
-}
-
 main ol {
   list-style-type: decimal;
   list-style-position: outside;


### PR DESCRIPTION
### What's being changed

Removing the float style for tables after h2 elements since there isn't a good way to conditionally clear it in the content without writing HTML.